### PR TITLE
Fix superclass mismatch error by loading transloadit/rails/version after transloadit/rails

### DIFF
--- a/lib/transloadit-rails.rb
+++ b/lib/transloadit-rails.rb
@@ -1,1 +1,2 @@
 require 'transloadit/rails'
+require 'transloadit/rails/version'

--- a/transloadit-rails.gemspec
+++ b/transloadit-rails.gemspec
@@ -1,6 +1,6 @@
 $:.unshift File.expand_path('../lib', __FILE__)
 
-require 'transloadit/rails/version'
+require 'transloadit-rails'
 
 Gem::Specification.new do |gem|
   gem.name     = 'transloadit-rails'


### PR DESCRIPTION
When you run the tests with bundler or include it into a Rails 3.0.7 environment you got a super class mismatch.

This fixes it by simply loading the version.rb after the rails.rb
