### PR TITLE
Process config file with ERB to allow dynamic configs

### DIFF
--- a/lib/transloadit/rails/engine.rb
+++ b/lib/transloadit/rails/engine.rb
@@ -27,7 +27,9 @@ class Transloadit
       end
 
       def self.configuration
-        YAML.load ERB.new(File.read(CONFIG_PATH)).result
+        config_file = self.application.root.join(CONFIG_PATH)
+        erb_result = ERB.new(File.read(config_file)).result
+        YAML.load erb_result
       end
 
       class << self


### PR DESCRIPTION
Unless I'm missing something, I needed to do this so that I could store my Transload.it and S3 keys on Heroku and obviously not store them in the actual config.

FYI this may be introducing a regression, because I wasn't sure why the current gem uses <code>self.application.root.join</code> rather than just loading the file.

So here's what my config looks like now:

<pre><code>
auth:
  key     : &lt;%= ENV['TRANSLOADIT_KEY'] %&gt;
  secret  : &lt;%= ENV['TRANSLOADIT_SECRET'] %&gt;
  duration: 1800 # 30 minute validity period for signed upload forms

templates:
  store_and_resize:
    steps:
      export:
        robot: "/s3/store"
        key: &lt;%= ENV['AWS_S3_KEY'] %&gt;
        secret: &lt;%= ENV['AWS_S3_SECRET'] %&gt;
        bucket: &lt;%= ENV['AWS_S3_BUCKET'] %&gt;
      thumb:
        robot: "/image/resize"
        width: 330
        height: 230
        resize_strategy: "pad"
        background: "#fff"
</code></pre>
