### PR TITLE
support per environment config

### DIFF
--- a/lib/transloadit/rails/engine.rb
+++ b/lib/transloadit/rails/engine.rb
@@ -41,6 +41,10 @@ class Transloadit
           @configuration = YAML.load(erb.result)
         end
 
+        if @configuration.keys.include?(::Rails.env)
+          @configuration = @configuration[::Rails.env]
+        end
+
         @configuration
       end
 


### PR DESCRIPTION
I needed a way to allow different environments to have different settings. I saw also that this is currently an open issue (https://github.com/transloadit/rails-sdk/issues/23). This pull request resolves the issue. 

I tried adding tests, but it doesn't look like the library is set up to handle engine testing. I can circle back around and add all of this later, if you need (although I'll switch it to rspec). 

Let me know if you have any questions.
