### PR TITLE
Bump dependency to transloadit gem to >= 1.1.1

### DIFF
--- a/transloadit-rails.gemspec
+++ b/transloadit-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.require_paths = %w{ lib }
 
-  gem.add_dependency 'transloadit', '>= 1.0.2'
+  gem.add_dependency 'transloadit', '>= 1.1.1'
   gem.add_dependency 'railties',    '>= 3'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
I think it's a good idea to bump this version to get more people on the new version of the transloadit gem. What do you think @stouset? Especially since there are a few versions between 1.0.2 and 1.1.1.
