### PR TITLE
Ruby 1.8.7 compatability: Convert symbol to string before downcase

### DIFF
--- a/lib/transloadit/rails/view_helper.rb
+++ b/lib/transloadit/rails/view_helper.rb
@@ -45,7 +45,7 @@ module Transloadit::Rails::ViewHelper
       ]
 
       js_options = options.map do |key, val|
-        "#{key.to_json}: #{callbacks.include?(key.downcase) ? val : val.to_json}"
+        "#{key.to_json}: #{callbacks.include?(key.to_s.downcase.to_sym) ? val : val.to_json}"
       end.join(",\n")
 
       "{#{js_options}}"


### PR DESCRIPTION
Ruby 1.8.7's Symbol does not have the downcase method (see [the docs](http://ruby-doc.org/core-1.8.7/Symbol.html)). This caused a NoMethodError to get thrown when using this library under 1.8.7.

I tried to write a test to capture this, but it proved to be fairly difficult to set up the test, so I went ahead and submitted the patch sans test.