### PR TITLE
Updated view_helper.rb to fix params issue

### DIFF
--- a/lib/transloadit/rails/view_helper.rb
+++ b/lib/transloadit/rails/view_helper.rb
@@ -7,7 +7,7 @@ module Transloadit::Rails::ViewHelper
   #
   def transloadit(template, options = {})
     params = Transloadit::Rails::Engine.template(template, options).to_json
-    fields = hidden_field_tag(:params, params, :id => nil)
+    fields = hidden_field_tag(:transloadit, params, :id => nil)
 
     if Transloadit::Rails::Engine.configuration['auth']['secret'].present?
       signature = Transloadit::Rails::Engine.sign(params)


### PR DESCRIPTION
Fixed a bug that was causing params[:transloadit] to be "nil" in the controlller.
