### PR TITLE
Remove Ruby 1.8 support, gem requires at least 1.9.2 now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: ruby
 rvm:
-  - ree
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - rbx-2
-  - jruby-18mode
   - jruby-19mode
 script: "bundle exec rake test"
 
@@ -20,19 +17,7 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: jruby-18mode
-      gemfile: gemfiles/4.0.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/4.0.gemfile
-    - rvm: ree
-      gemfile: gemfiles/4.0.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/4.0.gemfile
-    - rvm: jruby-18mode
-      gemfile: gemfiles/4.1.gemfile
-    - rvm: 1.8.7
-      gemfile: gemfiles/4.1.gemfile
-    - rvm: ree
-      gemfile: gemfiles/4.1.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/4.1.gemfile

--- a/transloadit-rails.gemspec
+++ b/transloadit-rails.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.description = 'The transloadit-rails gem allows you to automate uploading files through the Transloadit REST API'
 
   gem.required_rubygems_version = '>= 1.3.6'
+  gem.required_ruby_version     = '>= 1.9.2'
   gem.rubyforge_project         = 'transloadit-rails'
 
   gem.files         = `git ls-files`.split("\n")
@@ -25,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'transloadit', '>= 1.1.1'
   gem.add_dependency 'railties',    '>= 3'
-  gem.add_dependency 'mime-types', '< 2.0.0' if RUBY_VERSION < '1.9'
+  gem.add_dependency 'mime-types'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
This is the counterpart to https://github.com/transloadit/ruby-sdk/pull/23, same things apply :)