### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/transloadit-rails.gemspec
+++ b/transloadit-rails.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.required_rubygems_version = '>= 2.1.0'
   gem.required_ruby_version     = '>= 2.1.0'
-  gem.rubyforge_project         = 'transloadit-rails'
 
   gem_ignored_files = `git ls-files examples`.split("\n")
   gem.files         = `git ls-files`.split("\n") - gem_ignored_files


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436