### PR TITLE
Fix note rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ class YourController
 end
 ```
 
-that way the `param[:transloadit]` is automatically decoded for you, if it exists
+That way the `param[:transloadit]` is automatically decoded for you, if it exists.
 
-<div class="alert alert-note" markdown="1">
-  **Note:** Since it's still very young, the Transloadit Rails SDK does not include batteries for it yet, but
-  if you're looking for a jQuery-less integration, check out [Uppy](https://transloadit.com/docs/sdks/uppy/), our next-gen file uploader for the web.
+<div class="alert alert-note">
+  <strong>Note:</strong> Since it's still very young, the Transloadit Rails SDK does not include batteries for it yet, but
+  if you're looking for a jQuery-less integration, check out <a href="https://transloadit.com/docs/sdks/uppy/">Uppy</a>, our next-gen file uploader for the web.
 </div>
 
 ## Tutorial


### PR DESCRIPTION
Fixing this:

<img width="859" alt="image" src="https://user-images.githubusercontent.com/375537/165293933-6ea348ae-0363-4473-b91b-52bb5aa7c497.png">

The result is:

<img width="993" alt="image" src="https://user-images.githubusercontent.com/375537/165294212-5bd69d7d-5b05-4a9b-a3b8-382be44dbde8.png">

*One more thing:* Made a minor change in addition — capitailzed a sentence above the note and added a period at the end of it.