### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/ci.yml`

Resolved refs:

- `ruby/setup-ruby@v1` -> `ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
